### PR TITLE
feat: configurations to run with https and readme about node version …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # unico-sdk-poc-vuejs
 
+## NodeJS Version
+
+```
+14.X.X
+```
+
 ## Project setup
 ```
 yarn install
@@ -40,6 +46,10 @@ npm run lint
 The configuration bundle genereted by Unico's portal must be putted in a public folder. Like the next topic.
 
 Obs: in case of incorrect bundle datas, an error "unable to get unico authentication" or "current host is not registre" will raise when trying to open the camera.
+
+## Server configurations
+
+In case of all configurations above was done and Camera doesn't open, verify if your application is running with https, example: https://0.0.0.0:8000 .
 
 ### Credentials Path
 Fill the file below with the bundle genereted by Unico's portal:

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -9,7 +9,10 @@
 export default {
   name: "HelloWorld",
   props: {
-    msg: String,
+    msg: {
+      type: String,
+      required: true,
+    },
   },
 };
 </script>

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  devServer: {
+    open: process.platform === "darwin",
+    host: "0.0.0.0",
+    port: 8080, // CHANGE YOUR PORT HERE!
+    https: true,
+    hotOnly: false,
+  },
+};


### PR DESCRIPTION
We had a problem to run the poc using vuejs because we needed to use https and node in the version 14.x.x to run. But that wasn't described into readme file