### PR TITLE
feat: Simplify SDK resource loading from v3.18.0

### DIFF
--- a/src/views/CameraCapture.vue
+++ b/src/views/CameraCapture.vue
@@ -141,7 +141,7 @@ export default {
     },
     unicoCamera() {
       return new UnicoCheckBuilder()
-        .setResourceDirectory("/resources")
+       // .setResourceDirectory("/resources") /*-- A partir da versão 3.18.0, o SDK busca os recursos adicionais automaticamente se o método setResourceDirectory não for usado e as configurações de CSP estiverem corretas. --*/
         .setModelsPath("/models")
         .setEnvironment(SDKEnvironmentTypes.UAT)
         .setTheme(this.unicoTheme)


### PR DESCRIPTION
# Description

Starting with version 3.18.0, the SDK automatically fetches additional resources.

With this update, implementing the `setResourceDirectory` method is no longer necessary for resource loading. Ensure that Content Security Policy (CSP) settings are correctly applied for the SDK to function properly.

# Demand

What demand does this Pull Request refer to?

- [ ] Bug
- [ ] Feature
- [X] update