### PR TITLE
feat: Atualizar unico-webframe para v3.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "unico-webframe": "3.20.10",
+    "unico-webframe": "3.21.0",
     "util": "^0.12.4",
     "vue": "^2.7.16",
     "vue-router": "^3.6.5",


### PR DESCRIPTION

        **Atualização automática** do SDK `unico-webframe` para a versão **`3.21.0`**.
        * **Data de Lançamento:** `09/09/2025`
        * **Notas da Versão:** [Clique aqui](https://devcenter.unico.io/idcloud/integracao/sdk/integracao-sdks/sdk-web/release-notes)
        